### PR TITLE
修复创建用户时报错

### DIFF
--- a/Server/routes/admin/admin.js
+++ b/Server/routes/admin/admin.js
@@ -84,7 +84,7 @@ function Admin()
     this.userCreate=async (req,res)=>{
         try
         {
-            let obj=await (this.admin.userCreate());
+            let obj=await (this.admin.userCreate(req.clientParam, req.clientParam.id, req.clientParam.photo));
             if(obj)
             {
                 util.ok(res,obj,"ok");


### PR DESCRIPTION
修复管理员创建用户时，报姓名密码不能为空的错误