### PR TITLE
修复从服务器获取二进制图片文件无法被前端正确解析

### DIFF
--- a/Client/web/common/js/net.js
+++ b/Client/web/common/js/net.js
@@ -4,6 +4,7 @@
 var config=require("./config");
 var resource=require("vue-resource")
 Vue.use(resource)
+Vue.http.options.responseType="blob";
 var net={};
 function getAllHeaders(obj) {
     var result={};


### PR DESCRIPTION
在B/S模式下，版本6.2.0，获取服务器图片，返回前端变成二进制文本乱码，并不是二进制流，前端显示报错。DOClever官网确实没有问题，最后调试发现问题出现在vue-resource上。
官方vue-resource:
<img width="501" alt="微信截图_20190723175201" src="https://user-images.githubusercontent.com/7520593/61702728-e3215400-ad72-11e9-9946-1257b0815eb9.png">
6.2.0vue-resource:
<img width="553" alt="微信截图_20190723175712" src="https://user-images.githubusercontent.com/7520593/61703063-62168c80-ad73-11e9-947a-6328c9342cca.png">

